### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is my implementation of the WeTransfer file-upload progress spinner. For this project, I chose to begin with `create-react-app` to get it up and running quickly, using the `typescript` template. I created CSS where necessary, but in general it is pretty minimal, as I focused on the Spinner functionality.
 
-View the [live demo](https://thirsty-archimedes-1aaf76.netlify.app/).
+View the updated [live demo](https://thirsty-swanson-cbfc31.netlify.app/).
+
+View the original [live demo](https://thirsty-archimedes-1aaf76.netlify.app/).
 
 ## Usage
 

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -6,76 +6,226 @@ exports[`App Renders correctly 1`] = `
 >
   <div
     className="demo"
-    style={
-      Object {
-        "height": 200,
-        "margin": "0 auto",
-        "textAlign": "center",
-        "width": 200,
-      }
-    }
   >
-    <svg
-      className="progress-spinner"
-      height="100%"
-      viewBox="-25 -25 400 400"
-      width="100%"
+    <div
+      className="demo-spinners"
     >
-      <circle
-        className="progress-circle"
-        cx={175}
-        cy={175}
-        fill="none"
-        r={175}
-        strokeWidth={25}
-      />
-      <circle
-        className="progress-bar"
-        cx={175}
-        cy={175}
-        fill="none"
-        r={175}
-        strokeDasharray="1100"
-        strokeDashoffset="1100"
-        strokeLinecap="round"
-        strokeWidth={25}
-        style={
-          Object {
-            "animationDuration": "2s",
-            "animationPlayState": "paused",
-            "strokeDashoffset": 1100,
-            "transformOrigin": "175px 175px",
-            "transition": "stroke-dashoffset 0.75s ease-out",
-          }
-        }
-        transform="rotate(-90 175 175)"
-      />
-      <text
-        className="percentage"
-        dominantBaseline="central"
-        textAnchor="middle"
-        x={175}
-        y={175}
+      <svg
+        className="progress-spinner"
+        height="33%"
+        viewBox="-25 -25 400 400"
+        width="33%"
       >
-        <tspan
-          className="percentage-value"
+        <circle
+          className="progress-circle"
+          cx={175}
+          cy={175}
+          r={175}
+          strokeWidth={25}
+        />
+        <circle
+          className="progress-bar"
+          cx={175}
+          cy={175}
+          r={175}
+          strokeDasharray={1100}
+          strokeWidth={25}
+          style={
+            Object {
+              "animationDuration": "2s",
+              "animationPlayState": "paused",
+              "strokeDashoffset": 1100,
+              "transformOrigin": "175px 175px",
+              "transition": "stroke-dashoffset 0.75s ease-out",
+            }
+          }
+        />
+        <text
+          className="svg-counter"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x={175}
+          y={175}
         >
-          0
-        </tspan>
-        <tspan
-          className="percentage-sup"
-          dx={6}
-          dy={-14}
+          <tspan
+            className="svg-counter-value"
+          >
+            0
+          </tspan>
+          <tspan
+            className="svg-counter-sup"
+            dx={6}
+            dy={-14}
+          >
+            %
+          </tspan>
+        </text>
+      </svg>
+      <svg
+        className="progress-spinner"
+        height="33%"
+        viewBox="-25 -25 300 300"
+        width="33%"
+      >
+        <circle
+          className="progress-circle"
+          cx={125}
+          cy={125}
+          r={125}
+          strokeWidth={25}
+        />
+        <circle
+          className="progress-bar"
+          cx={125}
+          cy={125}
+          r={125}
+          strokeDasharray={785}
+          strokeWidth={25}
+          style={
+            Object {
+              "animationDuration": "1.5s",
+              "animationPlayState": "paused",
+              "strokeDashoffset": 785,
+              "transformOrigin": "125px 125px",
+              "transition": "stroke-dashoffset 0.5s ease-out",
+            }
+          }
+        />
+        <text
+          className="svg-counter"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x={125}
+          y={125}
         >
-          %
-        </tspan>
-      </text>
-    </svg>
-    <button
-      onClick={[Function]}
+          <tspan
+            className="svg-counter-value"
+          >
+            0
+          </tspan>
+          <tspan
+            className="svg-counter-sup"
+            dx={6}
+            dy={-14}
+          >
+            %
+          </tspan>
+        </text>
+      </svg>
+      <svg
+        className="progress-spinner"
+        height="33%"
+        viewBox="-40 -40 310 310"
+        width="33%"
+      >
+        <circle
+          className="progress-circle"
+          cx={115}
+          cy={115}
+          r={115}
+          strokeWidth={40}
+        />
+        <circle
+          className="progress-bar"
+          cx={115}
+          cy={115}
+          r={115}
+          strokeDasharray={723}
+          strokeWidth={40}
+          style={
+            Object {
+              "animationDuration": "1.25s",
+              "animationPlayState": "paused",
+              "stroke": "#884499",
+              "strokeDashoffset": 723,
+              "strokeLinecap": "unset",
+              "transformOrigin": "115px 115px",
+              "transition": "stroke-dashoffset 0.5s ease-out",
+            }
+          }
+        />
+        <text
+          className="svg-counter"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x={115}
+          y={115}
+        >
+          <tspan
+            className="svg-counter-value"
+          >
+            0
+          </tspan>
+          <tspan
+            className="svg-counter-sup"
+            dx={6}
+            dy={-14}
+          >
+            %
+          </tspan>
+        </text>
+      </svg>
+      <svg
+        className="progress-spinner"
+        height={300}
+        viewBox="-25 -25 650 650"
+        width={300}
+      >
+        <circle
+          className="progress-circle"
+          cx={300}
+          cy={300}
+          r={300}
+          strokeWidth={25}
+        />
+        <circle
+          className="progress-bar"
+          cx={300}
+          cy={300}
+          r={300}
+          strokeDasharray={1885}
+          strokeWidth={25}
+          style={
+            Object {
+              "animationDuration": "4s",
+              "animationPlayState": "paused",
+              "strokeDashoffset": 1885,
+              "transformOrigin": "300px 300px",
+              "transition": "stroke-dashoffset 1.25s ease-out",
+            }
+          }
+        />
+        <text
+          className="svg-counter"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="47%"
+          y="47%"
+        >
+          <tspan
+            className="svg-counter-value"
+          >
+            0
+          </tspan>
+          <tspan
+            className="svg-counter-sup"
+            dx={6}
+            dy={-14}
+          >
+            %
+          </tspan>
+        </text>
+      </svg>
+    </div>
+    <div
+      className="demo-buttons"
     >
-      Start
-    </button>
+      <button
+        onClick={[Function]}
+      >
+        Start
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -115,31 +115,31 @@ exports[`App Renders correctly 1`] = `
       <svg
         className="progress-spinner"
         height="33%"
-        viewBox="-40 -40 310 310"
+        viewBox="-40 -40 300 300"
         width="33%"
       >
         <circle
           className="progress-circle"
-          cx={115}
-          cy={115}
-          r={115}
+          cx={110}
+          cy={110}
+          r={110}
           strokeWidth={40}
         />
         <circle
           className="progress-bar"
-          cx={115}
-          cy={115}
-          r={115}
-          strokeDasharray={723}
+          cx={110}
+          cy={110}
+          r={110}
+          strokeDasharray={691}
           strokeWidth={40}
           style={
             Object {
               "animationDuration": "1.25s",
               "animationPlayState": "paused",
               "stroke": "#884499",
-              "strokeDashoffset": 723,
+              "strokeDashoffset": 691,
               "strokeLinecap": "unset",
-              "transformOrigin": "115px 115px",
+              "transformOrigin": "110px 110px",
               "transition": "stroke-dashoffset 0.5s ease-out",
             }
           }
@@ -148,8 +148,8 @@ exports[`App Renders correctly 1`] = `
           className="svg-counter"
           dominantBaseline="central"
           textAnchor="middle"
-          x={115}
-          y={115}
+          x={110}
+          y={110}
         >
           <tspan
             className="svg-counter-value"
@@ -216,6 +216,59 @@ exports[`App Renders correctly 1`] = `
           </tspan>
         </text>
       </svg>
+      <div
+        className="html-spinner-container"
+      >
+        <svg
+          className="progress-spinner"
+          height="100%"
+          viewBox="-25 -25 400 400"
+          width="100%"
+        >
+          <circle
+            className="progress-circle"
+            cx={175}
+            cy={175}
+            r={175}
+            strokeWidth={25}
+          />
+          <circle
+            className="progress-bar"
+            cx={175}
+            cy={175}
+            r={175}
+            strokeDasharray={1100}
+            strokeWidth={25}
+            style={
+              Object {
+                "animationDuration": "2s",
+                "animationPlayState": "paused",
+                "strokeDashoffset": 1100,
+                "transformOrigin": "175px 175px",
+                "transition": "stroke-dashoffset 1s ease-out",
+              }
+            }
+          />
+        </svg>
+        <div
+          className="html-counter"
+        >
+          <span
+            className="html-counter-value"
+          >
+            <span
+              className="html-counter-percentage"
+            >
+              0
+            </span>
+            <span
+              className="html-counter-sup"
+            >
+              %
+            </span>
+          </span>
+        </div>
+      </div>
     </div>
     <div
       className="demo-buttons"

--- a/src/components/Demo.css
+++ b/src/components/Demo.css
@@ -7,6 +7,8 @@
 .demo-spinners {
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-around;
+  align-items: center;
 }
 
 .demo-buttons {

--- a/src/components/Demo.css
+++ b/src/components/Demo.css
@@ -1,0 +1,14 @@
+.demo {
+  margin: 0 auto;
+  text-align: center;
+  width: 600px;
+}
+
+.demo-spinners {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.demo-buttons {
+  margin: 20px 0;
+}

--- a/src/components/Demo.css
+++ b/src/components/Demo.css
@@ -12,3 +12,9 @@
 .demo-buttons {
   margin: 20px 0;
 }
+
+.html-spinner-container {
+  width: 200px;
+  height: 200px;
+  position: relative;
+}

--- a/src/components/Demo.test.tsx
+++ b/src/components/Demo.test.tsx
@@ -45,6 +45,6 @@ describe('Demo', () => {
       }),
     );
     // This type of test would be better suited to Enzyme:
-    expect(container.getElementsByClassName('percentage-value')[0].innerHTML).not.toBe('0');
+    expect(container.getElementsByClassName('svg-counter-value')[0].innerHTML).not.toBe('0');
   });
 });

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -25,9 +25,9 @@ const Demo: FC = (): ReactElement => {
     if (progress === 100) {
       setProgress(0);
     } else {
-      // Increment progress by a number between 1 and 5, with the result not
+      // Increment progress by a number between 1 and 8, with the result not
       // exceeding 100:
-      setProgress(Math.min(progress + Math.floor(Math.random() * 5) + 1, 100));
+      setProgress(Math.min(progress + Math.floor(Math.random() * 8) + 1, 100));
     }
   }, [progress]);
 
@@ -40,10 +40,12 @@ const Demo: FC = (): ReactElement => {
           case 100:
             return 1000;
           default:
-            // Multiply 80ms by a random number between 1 and 5
-            return (Math.floor(Math.random() * 5) + 1) * 80;
+            // Multiply 150ms by a random number between 1 and 5
+            return (Math.floor(Math.random() * 5) + 1) * 150;
         }
       })();
+      // Using "window.setTimeout" instead of "setTimeout" as it returns
+      // a number we can use to easily store in state:
       const id: number = window.setTimeout(spin, duration);
       setTimeoutId(id);
     }
@@ -55,14 +57,14 @@ const Demo: FC = (): ReactElement => {
   };
 
   const handleStopSpinning = () => {
-    clearTimeout(timeoutId)
+    clearTimeout(timeoutId);
     toggleIsSpinning();
   };
 
   // Define radius for each demo spinner:
   const radius1 = 175;
   const radius2 = 125;
-  const radius3 = 110;
+  const radius3 = 120;
   const radius4 = 300;
 
   return (
@@ -87,7 +89,7 @@ const Demo: FC = (): ReactElement => {
           rotate={isSpinning}
           rotateDuration={1.5}
           radius={radius2}
-          size='33%'
+          size='38%'
         >
           <SVGCounter
             x={radius2}
@@ -101,7 +103,7 @@ const Demo: FC = (): ReactElement => {
           rotate={isSpinning}
           rotateDuration={1.25}
           radius={radius3}
-          size='33%'
+          size='28%'
           strokeWidth={40}
           progressStyles={{ stroke: '#884499', strokeLinecap: 'unset' }}
         >
@@ -115,7 +117,7 @@ const Demo: FC = (): ReactElement => {
           progress={progress}
           transitionDuration={1.25}
           rotate={isSpinning}
-          rotateDuration={4}
+          rotateDuration={10}
           radius={radius4}
           size={radius4}
         >
@@ -127,7 +129,8 @@ const Demo: FC = (): ReactElement => {
         </Spinner>
         <SpinnerWithHTMLCounter
           progress={progress}
-          rotate={isSpinning}
+          rotate={false}
+          transitionDuration={0.8}
         />
       </div>
       <div className='demo-buttons'>

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -7,7 +7,10 @@ import {
 } from 'react';
 import Spinner from './Spinner';
 import SVGCounter from './SVGCounter';
+import withHTMLCounter from './withHTMLCounter';
 import './Demo.css';
+
+const SpinnerWithHTMLCounter = withHTMLCounter(Spinner);
 
 const Demo: FC = (): ReactElement => {
   const [progress, setProgress] = useState(0);
@@ -56,7 +59,7 @@ const Demo: FC = (): ReactElement => {
   // Define radius for each demo spinner:
   const radius1 = 175;
   const radius2 = 125;
-  const radius3 = 115;
+  const radius3 = 110;
   const radius4 = 300;
 
   return (
@@ -119,6 +122,10 @@ const Demo: FC = (): ReactElement => {
             percentage={progress}
           />
         </Spinner>
+        <SpinnerWithHTMLCounter
+          progress={progress}
+          rotate={isSpinning}
+        />
       </div>
       <div className='demo-buttons'>
         {isSpinning

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -1,5 +1,4 @@
 import {
-  CSSProperties,
   FC,
   ReactElement,
   useCallback,
@@ -7,13 +6,8 @@ import {
   useState,
 } from 'react';
 import Spinner from './Spinner';
-
-const styles: CSSProperties = {
-  width: 200,
-  height: 200,
-  margin: '0 auto',
-  textAlign: 'center',
-};
+import SVGCounter from './SVGCounter';
+import './Demo.css';
 
 const Demo: FC = (): ReactElement => {
   const [progress, setProgress] = useState(0);
@@ -46,7 +40,7 @@ const Demo: FC = (): ReactElement => {
           return (Math.floor(Math.random() * 5) + 1) * 80;
         }
       })();
-      setTimeout(spin, duration)
+      setTimeout(spin, duration);
     }
   }, [progress]);
 
@@ -59,13 +53,78 @@ const Demo: FC = (): ReactElement => {
     toggleIsSpinning();
   };
 
+  // Define radius for each demo spinner:
+  const radius1 = 175;
+  const radius2 = 125;
+  const radius3 = 115;
+  const radius4 = 300;
+
   return (
-    <div className='demo' style={styles}>
-      <Spinner progress={progress} transitionDuration={0.75} rotate={isSpinning} />
-      {!isSpinning
-        && <button onClick={handleStartSpinning}>Start</button>}
-      {isSpinning
-        && <button onClick={handleStopSpinning}>End</button>}
+    <div className='demo'>
+      <div className='demo-spinners'>
+        <Spinner
+          progress={progress}
+          transitionDuration={0.75}
+          rotate={isSpinning}
+          radius={radius1}
+          size='33%'
+        >
+          <SVGCounter
+            x={radius1}
+            y={radius1}
+            percentage={progress}
+          />
+        </Spinner>
+        <Spinner
+          progress={progress}
+          transitionDuration={0.50}
+          rotate={isSpinning}
+          rotateDuration={1.5}
+          radius={radius2}
+          size='33%'
+        >
+          <SVGCounter
+            x={radius2}
+            y={radius2}
+            percentage={progress}
+          />
+        </Spinner>
+        <Spinner
+          progress={progress}
+          transitionDuration={0.50}
+          rotate={isSpinning}
+          rotateDuration={1.25}
+          radius={radius3}
+          size='33%'
+          strokeWidth={40}
+          progressStyles={{ stroke: '#884499', strokeLinecap: 'unset' }}
+        >
+          <SVGCounter
+            x={radius3}
+            y={radius3}
+            percentage={progress}
+          />
+        </Spinner>
+        <Spinner
+          progress={progress}
+          transitionDuration={1.25}
+          rotate={isSpinning}
+          rotateDuration={4}
+          radius={radius4}
+          size={radius4}
+        >
+          <SVGCounter
+            x='47%'
+            y='47%'
+            percentage={progress}
+          />
+        </Spinner>
+      </div>
+      <div className='demo-buttons'>
+        {isSpinning
+          ? <button onClick={handleStopSpinning}>End</button>
+          : <button onClick={handleStartSpinning}>Start</button>}
+      </div>
     </div>
   );
 };

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -49,6 +49,7 @@ const Demo: FC = (): ReactElement => {
       const id: number = window.setTimeout(spin, duration);
       setTimeoutId(id);
     }
+    return () => clearTimeout(timeoutId);
   }, [progress]);
 
   const handleStartSpinning = () => {

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -15,6 +15,7 @@ const SpinnerWithHTMLCounter = withHTMLCounter(Spinner);
 const Demo: FC = (): ReactElement => {
   const [progress, setProgress] = useState(0);
   const [isSpinning, setIsSpinning] = useState(false);
+  const [timeoutId, setTimeoutId] = useState(0);
 
   const toggleIsSpinning = () => {
     setIsSpinning(!isSpinning);
@@ -34,16 +35,17 @@ const Demo: FC = (): ReactElement => {
     if (isSpinning) {
       const duration = (() => {
         switch(progress) {
-        case 0:
-          return 1500;
-        case 100:
-          return 1000;
-        default:
-          // Multiply 80ms by a random number between 1 and 5
-          return (Math.floor(Math.random() * 5) + 1) * 80;
+          case 0:
+            return 1500;
+          case 100:
+            return 1000;
+          default:
+            // Multiply 80ms by a random number between 1 and 5
+            return (Math.floor(Math.random() * 5) + 1) * 80;
         }
       })();
-      setTimeout(spin, duration);
+      const id: number = window.setTimeout(spin, duration);
+      setTimeoutId(id);
     }
   }, [progress]);
 
@@ -53,6 +55,7 @@ const Demo: FC = (): ReactElement => {
   };
 
   const handleStopSpinning = () => {
+    clearTimeout(timeoutId)
     toggleIsSpinning();
   };
 

--- a/src/components/HTMLCounter.css
+++ b/src/components/HTMLCounter.css
@@ -1,0 +1,24 @@
+.html-counter {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 48px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.html-counter-percentage {
+  color: #333;
+  vertical-align: baseline;
+}
+
+.html-counter-sup {
+  vertical-align: super;
+  font-size: 18px;
+  font-weight: bold;
+  color: #c3c3c3;
+}

--- a/src/components/HTMLCounter.tsx
+++ b/src/components/HTMLCounter.tsx
@@ -1,0 +1,21 @@
+import { FC, ReactElement } from 'react';
+import { getValidPercentage } from '../util';
+import './HTMLCounter.css';
+
+type Props = {
+  percentage: number;
+};
+
+const HTMLCounter: FC<Props> = (props: Props): ReactElement => {
+  const { percentage } = props;
+  return (
+    <div className='html-counter'>
+      <span className='html-counter-value'>
+        <span className='html-counter-percentage'>{getValidPercentage(percentage)}</span>
+        <span className='html-counter-sup'>%</span>
+      </span>
+    </div>
+  );
+};
+
+export default HTMLCounter;

--- a/src/components/SVGCounter.css
+++ b/src/components/SVGCounter.css
@@ -1,0 +1,11 @@
+.svg-counter {
+  font-family: Arial, Helvetica, sans-serif;
+  fill: #333;
+  font-size: 88px;
+}
+
+.svg-counter-sup {
+  fill: #c3c3c3;
+  font-size: 32px;
+  font-weight: bold;
+}

--- a/src/components/SVGCounter.tsx
+++ b/src/components/SVGCounter.tsx
@@ -12,16 +12,16 @@ const SVGCounter: FC<Props> = (props: Props): ReactElement => {
   const { x, y, percentage } = props;
   return (
     <text
-        className='svg-counter'
-        x={x}
-        y={y}
-        textAnchor='middle'
-        dominantBaseline='central'
+      className='svg-counter'
+      x={x}
+      y={y}
+      textAnchor='middle'
+      dominantBaseline='central'
     >
       <tspan className='svg-counter-value'>{getValidPercentage(percentage)}</tspan>
       <tspan dx={6} dy={-14} className='svg-counter-sup'>%</tspan>
     </text>
-  )
+  );
 };
 
 export default SVGCounter;

--- a/src/components/SVGCounter.tsx
+++ b/src/components/SVGCounter.tsx
@@ -1,0 +1,27 @@
+import { FC, ReactElement } from 'react';
+import { getValidPercentage } from '../util';
+import './SVGCounter.css';
+
+type Props = {
+  x: number | string;
+  y: number | string;
+  percentage: number;
+};
+
+const SVGCounter: FC<Props> = (props: Props): ReactElement => {
+  const { x, y, percentage } = props;
+  return (
+    <text
+        className='svg-counter'
+        x={x}
+        y={y}
+        textAnchor='middle'
+        dominantBaseline='central'
+    >
+      <tspan className='svg-counter-value'>{getValidPercentage(percentage)}</tspan>
+      <tspan dx={6} dy={-14} className='svg-counter-sup'>%</tspan>
+    </text>
+  )
+};
+
+export default SVGCounter;

--- a/src/components/Spinner.css
+++ b/src/components/Spinner.css
@@ -1,8 +1,3 @@
-.progress-spinner {
-  position: relative;
-  z-index: -1;
-}
-
 .progress-bar {
   stroke: #479ef2;
   fill: none;

--- a/src/components/Spinner.css
+++ b/src/components/Spinner.css
@@ -1,29 +1,28 @@
+.progress-spinner {
+  position: relative;
+  z-index: -1;
+}
+
 .progress-bar {
   stroke: #479ef2;
+  fill: none;
+  stroke-linecap: round;
   animation-name: rotateProgress;
   animation-fill-mode: forwards;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
 }
 
-.progress-circle {
-  stroke: #e9e9e9;
-}
-
 @keyframes rotateProgress {
+  from {
+    transform: rotate(-90deg);
+  }
   to {
-    transform: rotate(360deg);
+    transform: rotate(270deg);
   }
 }
 
-.percentage {
-  font-family: Arial, Helvetica, sans-serif;
-  fill: #333;
-  font-size: 88px;
-}
-
-.percentage-sup {
-  fill: #c3c3c3;
-  font-size: 32px;
-  font-weight: bold;
+.progress-circle {
+  stroke: #e9e9e9;
+  fill: none;
 }

--- a/src/components/Spinner.test.tsx
+++ b/src/components/Spinner.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import Spinner from './Spinner';
+import SVGCounter from './SVGCounter';
 
 describe('Spinner', () => {
   it('Renders correctly', () => {
@@ -10,14 +11,23 @@ describe('Spinner', () => {
   });
 
   it('should initialize at zero with no props provided', () => {
-    const { container } = render(<Spinner />);
+    const radius = 175;
+    const { container } = render(
+      <Spinner radius={radius}>
+        <SVGCounter x={radius} y={radius} percentage={0} />
+      </Spinner>);
     // This type of test would be better suited to Enzyme:
-    expect(container.getElementsByClassName('percentage-value')[0].innerHTML).toBe('0');
+    expect(container.getElementsByClassName('svg-counter-value')[0].innerHTML).toBe('0');
   });
 
   it('should set the percentage value equal to the prop progress', () => {
-    const { container } = render(<Spinner progress={35} />);
+    const radius = 175;
+    const progress = 35;
+    const { container } = render(
+      <Spinner radius={radius} progress={progress}>
+        <SVGCounter x={radius} y={radius} percentage={progress} />
+      </Spinner>);
     // This type of test would be better suited to Enzyme:
-    expect(container.getElementsByClassName('percentage-value')[0].innerHTML).toBe('35');
+    expect(container.getElementsByClassName('svg-counter-value')[0].innerHTML).toBe('35');
   });
 });

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,16 +1,22 @@
 import { CSSProperties, FC, ReactElement } from 'react';
-import { getOffset, getValidPercentage } from '../util';
+import {
+  getOffset,
+  getValidPercentage,
+  calculateDiameter,
+  getViewBoxForCircle,
+} from '../util';
 import './Spinner.css';
 
 type Props = {
   progress?: number;
   transitionDuration?: number;
   size?: number | string;
-  radius?: number,
-  strokeWidth?: number,
-  progressStyles?: CSSProperties,
+  radius?: number;
+  strokeWidth?: number;
+  progressStyles?: CSSProperties;
   rotate?: boolean;
-  rotateDuration?: number,
+  rotateDuration?: number;
+  children?: JSX.Element;
 };
 
 const Spinner: FC<Props> = (props: Props): ReactElement => {
@@ -18,60 +24,52 @@ const Spinner: FC<Props> = (props: Props): ReactElement => {
     progress = 0,
     transitionDuration = 1,
     size = '100%',
+    radius = 175,
     strokeWidth = 25,
     progressStyles = {},
     rotate = false,
     rotateDuration = 2,
+    children,
   } = props;
 
-  const radius = 175;
-  const diameter = Math.round(Math.PI * radius * 2);
-
+  const diameter = calculateDiameter(radius);
+  const validPercentage = getValidPercentage(progress);
+  const viewBox = getViewBoxForCircle(radius, strokeWidth);
   const progressStyle: CSSProperties = {
     strokeDashoffset: getOffset(progress, diameter),
     transition: `stroke-dashoffset ${transitionDuration}s ease-out`,
     transformOrigin: `${radius}px ${radius}px`,
     animationDuration: `${rotateDuration}s`,
     // Rotate progress bar when rotate is true, and progress is over zero
-    animationPlayState: (rotate && progress > 0) ? 'running' : 'paused',
+    animationPlayState: (rotate && validPercentage > 0) ? 'running' : 'paused',
     // Styles can be overridden
     ...progressStyles,
   };
 
-  const validPercentage = getValidPercentage(progress);
-
   return (
-    <svg className='progress-spinner' width={size} height={size} viewBox='-25 -25 400 400'>
+    <svg
+      className='progress-spinner'
+      width={size}
+      height={size}
+      viewBox={viewBox}
+    >
       <circle
         className='progress-circle'
         cx={radius}
         cy={radius}
         r={radius}
         strokeWidth={strokeWidth}
-        fill='none' />
+      />
       <circle
         className='progress-bar'
         cx={radius}
         cy={radius}
         r={radius}
-        transform={`rotate(-90 ${radius} ${radius})`}
         strokeWidth={strokeWidth}
-        strokeDasharray='1100'
-        strokeDashoffset='1100'
-        strokeLinecap='round'
+        strokeDasharray={diameter}
         style={progressStyle}
-        fill='none'
       />
-      <text
-        className='percentage'
-        x={radius}
-        y={radius}
-        textAnchor='middle'
-        dominantBaseline='central'
-      >
-        <tspan className='percentage-value'>{validPercentage}</tspan>
-        <tspan dx={6} dy={-14} className='percentage-sup'>%</tspan>
-      </text>
+      {children}
     </svg>
   );
 };

--- a/src/components/__snapshots__/Demo.test.tsx.snap
+++ b/src/components/__snapshots__/Demo.test.tsx.snap
@@ -3,75 +3,225 @@
 exports[`Demo Renders correctly 1`] = `
 <div
   className="demo"
-  style={
-    Object {
-      "height": 200,
-      "margin": "0 auto",
-      "textAlign": "center",
-      "width": 200,
-    }
-  }
 >
-  <svg
-    className="progress-spinner"
-    height="100%"
-    viewBox="-25 -25 400 400"
-    width="100%"
+  <div
+    className="demo-spinners"
   >
-    <circle
-      className="progress-circle"
-      cx={175}
-      cy={175}
-      fill="none"
-      r={175}
-      strokeWidth={25}
-    />
-    <circle
-      className="progress-bar"
-      cx={175}
-      cy={175}
-      fill="none"
-      r={175}
-      strokeDasharray="1100"
-      strokeDashoffset="1100"
-      strokeLinecap="round"
-      strokeWidth={25}
-      style={
-        Object {
-          "animationDuration": "2s",
-          "animationPlayState": "paused",
-          "strokeDashoffset": 1100,
-          "transformOrigin": "175px 175px",
-          "transition": "stroke-dashoffset 0.75s ease-out",
-        }
-      }
-      transform="rotate(-90 175 175)"
-    />
-    <text
-      className="percentage"
-      dominantBaseline="central"
-      textAnchor="middle"
-      x={175}
-      y={175}
+    <svg
+      className="progress-spinner"
+      height="33%"
+      viewBox="-25 -25 400 400"
+      width="33%"
     >
-      <tspan
-        className="percentage-value"
+      <circle
+        className="progress-circle"
+        cx={175}
+        cy={175}
+        r={175}
+        strokeWidth={25}
+      />
+      <circle
+        className="progress-bar"
+        cx={175}
+        cy={175}
+        r={175}
+        strokeDasharray={1100}
+        strokeWidth={25}
+        style={
+          Object {
+            "animationDuration": "2s",
+            "animationPlayState": "paused",
+            "strokeDashoffset": 1100,
+            "transformOrigin": "175px 175px",
+            "transition": "stroke-dashoffset 0.75s ease-out",
+          }
+        }
+      />
+      <text
+        className="svg-counter"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x={175}
+        y={175}
       >
-        0
-      </tspan>
-      <tspan
-        className="percentage-sup"
-        dx={6}
-        dy={-14}
+        <tspan
+          className="svg-counter-value"
+        >
+          0
+        </tspan>
+        <tspan
+          className="svg-counter-sup"
+          dx={6}
+          dy={-14}
+        >
+          %
+        </tspan>
+      </text>
+    </svg>
+    <svg
+      className="progress-spinner"
+      height="33%"
+      viewBox="-25 -25 300 300"
+      width="33%"
+    >
+      <circle
+        className="progress-circle"
+        cx={125}
+        cy={125}
+        r={125}
+        strokeWidth={25}
+      />
+      <circle
+        className="progress-bar"
+        cx={125}
+        cy={125}
+        r={125}
+        strokeDasharray={785}
+        strokeWidth={25}
+        style={
+          Object {
+            "animationDuration": "1.5s",
+            "animationPlayState": "paused",
+            "strokeDashoffset": 785,
+            "transformOrigin": "125px 125px",
+            "transition": "stroke-dashoffset 0.5s ease-out",
+          }
+        }
+      />
+      <text
+        className="svg-counter"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x={125}
+        y={125}
       >
-        %
-      </tspan>
-    </text>
-  </svg>
-  <button
-    onClick={[Function]}
+        <tspan
+          className="svg-counter-value"
+        >
+          0
+        </tspan>
+        <tspan
+          className="svg-counter-sup"
+          dx={6}
+          dy={-14}
+        >
+          %
+        </tspan>
+      </text>
+    </svg>
+    <svg
+      className="progress-spinner"
+      height="33%"
+      viewBox="-40 -40 310 310"
+      width="33%"
+    >
+      <circle
+        className="progress-circle"
+        cx={115}
+        cy={115}
+        r={115}
+        strokeWidth={40}
+      />
+      <circle
+        className="progress-bar"
+        cx={115}
+        cy={115}
+        r={115}
+        strokeDasharray={723}
+        strokeWidth={40}
+        style={
+          Object {
+            "animationDuration": "1.25s",
+            "animationPlayState": "paused",
+            "stroke": "#884499",
+            "strokeDashoffset": 723,
+            "strokeLinecap": "unset",
+            "transformOrigin": "115px 115px",
+            "transition": "stroke-dashoffset 0.5s ease-out",
+          }
+        }
+      />
+      <text
+        className="svg-counter"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x={115}
+        y={115}
+      >
+        <tspan
+          className="svg-counter-value"
+        >
+          0
+        </tspan>
+        <tspan
+          className="svg-counter-sup"
+          dx={6}
+          dy={-14}
+        >
+          %
+        </tspan>
+      </text>
+    </svg>
+    <svg
+      className="progress-spinner"
+      height={300}
+      viewBox="-25 -25 650 650"
+      width={300}
+    >
+      <circle
+        className="progress-circle"
+        cx={300}
+        cy={300}
+        r={300}
+        strokeWidth={25}
+      />
+      <circle
+        className="progress-bar"
+        cx={300}
+        cy={300}
+        r={300}
+        strokeDasharray={1885}
+        strokeWidth={25}
+        style={
+          Object {
+            "animationDuration": "4s",
+            "animationPlayState": "paused",
+            "strokeDashoffset": 1885,
+            "transformOrigin": "300px 300px",
+            "transition": "stroke-dashoffset 1.25s ease-out",
+          }
+        }
+      />
+      <text
+        className="svg-counter"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="47%"
+        y="47%"
+      >
+        <tspan
+          className="svg-counter-value"
+        >
+          0
+        </tspan>
+        <tspan
+          className="svg-counter-sup"
+          dx={6}
+          dy={-14}
+        >
+          %
+        </tspan>
+      </text>
+    </svg>
+  </div>
+  <div
+    className="demo-buttons"
   >
-    Start
-  </button>
+    <button
+      onClick={[Function]}
+    >
+      Start
+    </button>
+  </div>
 </div>
 `;

--- a/src/components/__snapshots__/Demo.test.tsx.snap
+++ b/src/components/__snapshots__/Demo.test.tsx.snap
@@ -112,31 +112,31 @@ exports[`Demo Renders correctly 1`] = `
     <svg
       className="progress-spinner"
       height="33%"
-      viewBox="-40 -40 310 310"
+      viewBox="-40 -40 300 300"
       width="33%"
     >
       <circle
         className="progress-circle"
-        cx={115}
-        cy={115}
-        r={115}
+        cx={110}
+        cy={110}
+        r={110}
         strokeWidth={40}
       />
       <circle
         className="progress-bar"
-        cx={115}
-        cy={115}
-        r={115}
-        strokeDasharray={723}
+        cx={110}
+        cy={110}
+        r={110}
+        strokeDasharray={691}
         strokeWidth={40}
         style={
           Object {
             "animationDuration": "1.25s",
             "animationPlayState": "paused",
             "stroke": "#884499",
-            "strokeDashoffset": 723,
+            "strokeDashoffset": 691,
             "strokeLinecap": "unset",
-            "transformOrigin": "115px 115px",
+            "transformOrigin": "110px 110px",
             "transition": "stroke-dashoffset 0.5s ease-out",
           }
         }
@@ -145,8 +145,8 @@ exports[`Demo Renders correctly 1`] = `
         className="svg-counter"
         dominantBaseline="central"
         textAnchor="middle"
-        x={115}
-        y={115}
+        x={110}
+        y={110}
       >
         <tspan
           className="svg-counter-value"
@@ -213,6 +213,59 @@ exports[`Demo Renders correctly 1`] = `
         </tspan>
       </text>
     </svg>
+    <div
+      className="html-spinner-container"
+    >
+      <svg
+        className="progress-spinner"
+        height="100%"
+        viewBox="-25 -25 400 400"
+        width="100%"
+      >
+        <circle
+          className="progress-circle"
+          cx={175}
+          cy={175}
+          r={175}
+          strokeWidth={25}
+        />
+        <circle
+          className="progress-bar"
+          cx={175}
+          cy={175}
+          r={175}
+          strokeDasharray={1100}
+          strokeWidth={25}
+          style={
+            Object {
+              "animationDuration": "2s",
+              "animationPlayState": "paused",
+              "strokeDashoffset": 1100,
+              "transformOrigin": "175px 175px",
+              "transition": "stroke-dashoffset 1s ease-out",
+            }
+          }
+        />
+      </svg>
+      <div
+        className="html-counter"
+      >
+        <span
+          className="html-counter-value"
+        >
+          <span
+            className="html-counter-percentage"
+          >
+            0
+          </span>
+          <span
+            className="html-counter-sup"
+          >
+            %
+          </span>
+        </span>
+      </div>
+    </div>
   </div>
   <div
     className="demo-buttons"

--- a/src/components/__snapshots__/Spinner.test.tsx.snap
+++ b/src/components/__snapshots__/Spinner.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`Spinner Renders correctly 1`] = `
     className="progress-circle"
     cx={175}
     cy={175}
-    fill="none"
     r={175}
     strokeWidth={25}
   />
@@ -19,11 +18,8 @@ exports[`Spinner Renders correctly 1`] = `
     className="progress-bar"
     cx={175}
     cy={175}
-    fill="none"
     r={175}
-    strokeDasharray="1100"
-    strokeDashoffset="1100"
-    strokeLinecap="round"
+    strokeDasharray={1100}
     strokeWidth={25}
     style={
       Object {
@@ -34,27 +30,6 @@ exports[`Spinner Renders correctly 1`] = `
         "transition": "stroke-dashoffset 1s ease-out",
       }
     }
-    transform="rotate(-90 175 175)"
   />
-  <text
-    className="percentage"
-    dominantBaseline="central"
-    textAnchor="middle"
-    x={175}
-    y={175}
-  >
-    <tspan
-      className="percentage-value"
-    >
-      55
-    </tspan>
-    <tspan
-      className="percentage-sup"
-      dx={6}
-      dy={-14}
-    >
-      %
-    </tspan>
-  </text>
 </svg>
 `;

--- a/src/components/withHTMLCounter.tsx
+++ b/src/components/withHTMLCounter.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+import HTMLCounter from './HTMLCounter';
+
+type Props = {
+  progress: number;
+};
+
+const withHTMLCounter = <P extends Record<string, unknown>>(
+  SpinnerComponent: React.ComponentType<P>
+): React.FC<P & Props> => 
+  (props: P & Props): ReactElement => {
+    const { progress: percentage } = props;
+    return (
+      <div className='html-spinner-container'>
+        <SpinnerComponent {...props} />
+        <HTMLCounter percentage={percentage} />
+      </div>
+    );
+};
+
+export default withHTMLCounter;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -37,4 +37,4 @@ export const calculateDiameter = (radius: number): number => {
 export const getViewBoxForCircle = (radius: number, strokeWidth: number): string => {
   const size = (radius * 2) + (strokeWidth * 2);
   return `${-strokeWidth} ${-strokeWidth} ${size} ${size}`;
-}
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -9,7 +9,8 @@ export const getValidPercentage = (progress: number): number => {
 
 /**
  * Calculate the SVG stroke-dashoffset value given a progress percentage
- * and a diameter
+ * and a diameter. For example, if progress == 0, the offset will equal
+ * the diameter. If progress == 100, the offset will equal zero.
  * @param {number} progress
  * @param {number} diameter
  * @returns {number}
@@ -17,3 +18,23 @@ export const getValidPercentage = (progress: number): number => {
 export const getOffset = (progress: number, diameter: number): number => {
   return Math.round((100 - getValidPercentage(progress)) / 100 * diameter);
 };
+
+/**
+ * Calculate diameter given a radius (2 * PI * r)
+ * @param {number} radius
+ * @returns {number}
+ */
+export const calculateDiameter = (radius: number): number => {
+  return Math.round(Math.PI * radius * 2);
+};
+
+/**
+ * Get the SVG viewBox string given a radius and stroke-width
+ * @param {string} radius
+ * @param {string} strokeWidth
+ * @returns {string}
+ */
+export const getViewBoxForCircle = (radius: number, strokeWidth: number): string => {
+  const size = (radius * 2) + (strokeWidth * 2);
+  return `${-strokeWidth} ${-strokeWidth} ${size} ${size}`;
+}

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -1,4 +1,9 @@
-import { getOffset, getValidPercentage } from '.';
+import {
+  getOffset,
+  getValidPercentage,
+  calculateDiameter,
+  getViewBoxForCircle,
+} from '.';
 
 describe('getOffset', () => {
   it('should return a valid offset', () => {
@@ -33,5 +38,27 @@ describe('getValidPercentage', () => {
     const progress = 5.1111;
     const actual = getValidPercentage(progress);
     expect(actual).toBe(5);
+  });
+});
+
+describe('calculateDiameter', () => {
+  it('should return the correct diameter', () => {
+    const radius = 175;
+    const expected = 1100;
+    const actual = calculateDiameter(radius);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('getViewBoxForCircle', () => {
+  it('should return the correct viewBox', () => {
+    const radius = 175;
+    const strokeWidth = 25;
+    // As the bounding box of a circle is a square, we calculate a viewBox
+    // with equal width & height. The X/Y values are the strokeWidth * -1,
+    // and the width & height are radius * 2 + strokeWidth (175*2+25):
+    const expected = '-25 -25 400 400';
+    const actual = getViewBoxForCircle(radius, strokeWidth);
+    expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
This PR is simply to illustrate some of the changes I would have liked to have implemented in the original assignment given more time. This update expands the original to make components more reusable. Specifically, the `text`  SVG element of the original `Spinner` component is a separate component (`SVGCounter`) that can be passed in as a child to `Spinner`. There is an additional component, `HTMLCounter`, that can be used instead via the HOC `withHTMLCounter`. The radius of the progress spinner now can be passed in as a prop, allowing much more control over the component. The SVG `viewBox` is now dynamically calculated and sized according to `radius` and `strokeWidth`. 